### PR TITLE
send email otp with mailgun instead of sendgrid

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,7 +7,6 @@
       "name": "functions",
       "dependencies": {
         "@google-cloud/kms": "^3.1.0",
-        "@sendgrid/mail": "^7.7.0",
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.2",
         "@types/nodemailer": "^6.4.5",
@@ -23,6 +22,7 @@
         "firebase-admin": "^11.4.1",
         "firebase-functions": "^4.2.1",
         "graphql": "^16.6.0",
+        "mailgun.js": "^8.2.0",
         "node-email-validation": "^1.0.4",
         "node-fetch": "^2.6.8",
         "node-html-parser": "^6.1.4",
@@ -1078,41 +1078,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
-    "node_modules/@sendgrid/client": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
-      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
-      "dependencies": {
-        "@sendgrid/helpers": "^7.7.0",
-        "axios": "^0.26.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >=10.*"
-      }
-    },
-    "node_modules/@sendgrid/helpers": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
-      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
-      "dependencies": {
-        "deepmerge": "^4.2.2"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sendgrid/mail": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
-      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
-      "dependencies": {
-        "@sendgrid/client": "^7.7.0",
-        "@sendgrid/helpers": "^7.7.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >=10.*"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1903,18 +1868,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -2365,14 +2327,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-    },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/define-properties": {
       "version": "1.1.4",
@@ -4668,6 +4622,39 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
+    "node_modules/mailgun.js": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-8.2.0.tgz",
+      "integrity": "sha512-4WtR5TK9uXEkrmotZ7EgETP0bExK7Y0+fYpNmPGdTPHfgPpZRH+G4mTm2/nvBB3AS+UuU0r9t9FieKKREdLM8w==",
+      "dependencies": {
+        "axios": "^1.3.3",
+        "base-64": "^1.0.0",
+        "url-join": "^4.0.1"
+      }
+    },
+    "node_modules/mailgun.js/node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/mailgun.js/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
@@ -5266,6 +5253,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -6156,6 +6148,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -7058,32 +7055,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
-    "@sendgrid/client": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
-      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
-      "requires": {
-        "@sendgrid/helpers": "^7.7.0",
-        "axios": "^0.26.0"
-      }
-    },
-    "@sendgrid/helpers": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
-      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
-      "requires": {
-        "deepmerge": "^4.2.2"
-      }
-    },
-    "@sendgrid/mail": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
-      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
-      "requires": {
-        "@sendgrid/client": "^7.7.0",
-        "@sendgrid/helpers": "^7.7.0"
-      }
-    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -7639,18 +7610,15 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "requires": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "base-x": {
       "version": "3.0.9",
@@ -8010,11 +7978,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-    },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.4",
@@ -9783,6 +9746,38 @@
         }
       }
     },
+    "mailgun.js": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-8.2.0.tgz",
+      "integrity": "sha512-4WtR5TK9uXEkrmotZ7EgETP0bExK7Y0+fYpNmPGdTPHfgPpZRH+G4mTm2/nvBB3AS+UuU0r9t9FieKKREdLM8w==",
+      "requires": {
+        "axios": "^1.3.3",
+        "base-64": "^1.0.0",
+        "url-join": "^4.0.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+          "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
@@ -10211,6 +10206,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -10869,6 +10869,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "@google-cloud/kms": "^3.1.0",
-    "@sendgrid/mail": "^7.7.0",
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.2",
     "@types/nodemailer": "^6.4.5",
@@ -33,6 +32,7 @@
     "firebase-admin": "^11.4.1",
     "firebase-functions": "^4.2.1",
     "graphql": "^16.6.0",
+    "mailgun.js": "^8.2.0",
     "node-email-validation": "^1.0.4",
     "node-fetch": "^2.6.8",
     "node-html-parser": "^6.1.4",

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -34,7 +34,7 @@ export async function genOTP(email: string) {
 
 export async function validateOTP(email: string, otp: string) {
     const validateOTPCall = httpsCallable(functions, 'validateOTP');
-    const result = await validateOTPCall({email: email, otp: otp});
+    const result = await validateOTPCall({email, otp});
     const resultData = result.data as any;
     if (resultData.code !== 200) {
         return {code: resultData.code, message: resultData.message}

--- a/src/views/SignInView.vue
+++ b/src/views/SignInView.vue
@@ -15,13 +15,13 @@
                         <span style="margin: 0 5px;">Sign in with Twitter</span>
                     </Button>
                 </div>
-                <!-- <p class="or"><span>or</span></p>
+                <p class="or"><span>or</span></p>
                 <div class="email-login">
                     <input type="text" v-model="email" placeholder="Enter Email" name="uname" class="email-input" required>
                 </div>
                 <Button class="cta-btn" type="primary" :loading="isLoadingLogin" :disabled="loginDisabled" @click="sendOTP">
                     Log In
-                </Button> -->
+                </Button>
             </div>
         </transition>
         <transition name="fade">
@@ -162,6 +162,7 @@ const sendOTP = async () => {
             }
             else if (result === 200) {
                 show.value = !show.value;
+                email.value = email.value.toLowerCase();
                 countDownTimer();
             }
         } catch (err) {


### PR DESCRIPTION
this diff is to replace sendgrid with mailgun since the sendgrid key is not working anymore. We tried to upgrade the plan but it's not helping. Per test, mailgun has better performance and lower delivery latency so let's switch to this provider.

Changes include:

1. added mailgun api key to doppler
2. use mailgun.js to send email otp

Rate limit:
Sendgrid has daily limit of 100 emails for free plan but mailgun doesn't have per day limit. The month limit of the free plan is 5000.