### PR TITLE
do not show claim footer when loading

### DIFF
--- a/src/components/RedPacketClaim.vue
+++ b/src/components/RedPacketClaim.vue
@@ -34,7 +34,7 @@
     <div class="cta-container transition" :style="claimItem == 'erc721' ? 'margin-top: 420px;' : 'margin-top: 360px;'">
       <button :disabled="!claimable" @click="claim" class="cta">{{ claimButtonText }}</button>
       <div v-if="!mounting && route.query.otp?.toString() != null && timeLeft <= 0" class="footer">
-        Token expired
+        Claim expired
       </div>
       <div v-if="!mounting && route.query.otp?.toString() != null && timeLeft > 0" class="footer">
         The request will expire in {{ timeLeft }} seconds

--- a/src/components/RedPacketClaim.vue
+++ b/src/components/RedPacketClaim.vue
@@ -32,11 +32,11 @@
       <small >Best Wishes!</small>
     </h2>
     <div class="cta-container transition" :style="claimItem == 'erc721' ? 'margin-top: 420px;' : 'margin-top: 360px;'">
-      <button v-if="claimable" @click="claim" class="cta" :disabled="mounting">{{ claimButtonText }}</button>
-      <div v-if="route.query.otp?.toString() != null && timeLeft <= 0" class="footer">
+      <button :disabled="!claimable" @click="claim" class="cta">{{ claimButtonText }}</button>
+      <div v-if="!mounting && route.query.otp?.toString() != null && timeLeft <= 0" class="footer">
         Token expired
       </div>
-      <div v-if="route.query.otp?.toString() != null && timeLeft > 0" class="footer">
+      <div v-if="!mounting && route.query.otp?.toString() != null && timeLeft > 0" class="footer">
         The request will expire in {{ timeLeft }} seconds
       </div>
     </div>
@@ -73,7 +73,6 @@ import { useRedPacketStore } from '@/stores/redpacket';
 import { useChainStore } from "@/stores/chain";
 import { prettyPrint, checkClaimer } from "@/services/util";
 import { copy } from "@/web3/utils";
-import { delay } from "wonka";
 
 const redPacket = ref<RedPacketDB | undefined>();
 const redPacketTokenIcon = ref<string>("");
@@ -136,8 +135,8 @@ onMounted(async () => {
 });
 
 const claimable = computed(() => {
-  return route.query.otp?.toString() == null ||
-    (route.query.otp?.toString() != null && timeLeft.value > 0)
+  const otp = route.query.otp?.toString();
+  return !mounting && (otp == null || (otp != null && timeLeft.value > 0));
 });
 
 const claim = async () => {


### PR DESCRIPTION
now if someone claims repo with dynamic link http://localhost:5173/airdrop?claim=$id&otp=$otp, we will show "Token Expired" at footer while loading, which is confusing. This diff is to disable the footer while loading and always show loading/claim button. There are three different cases:

1. loading data. We will show "Loading" button(which is disabled) and hide the footer.
2. data is loaded and the claim is not expired. We will show claim button and the counting down footer.
3. claim is expired. We will show claim button(which is disabled) and show the "Claim Expired" button.

I also updated the "Token expired" to "Claim expired" since it doesn't make sense to say a token is expired.