### PR TITLE
fix claim button state

### DIFF
--- a/src/components/RedPacketClaim.vue
+++ b/src/components/RedPacketClaim.vue
@@ -136,7 +136,7 @@ onMounted(async () => {
 
 const claimable = computed(() => {
   const otp = route.query.otp?.toString();
-  return !mounting && (otp == null || (otp != null && timeLeft.value > 0));
+  return !mounting.value && (otp == null || (otp != null && timeLeft.value > 0));
 });
 
 const claim = async () => {


### PR DESCRIPTION
mounting will always return true since it's ref type. We should use mounting.value otherwise the button is always disabled