### PR TITLE
Fix the created token airdrop amount number format on luck history page

### DIFF
--- a/functions/common/lib.esm/utils.d.ts
+++ b/functions/common/lib.esm/utils.d.ts
@@ -13,6 +13,7 @@ export interface NormalizedTokenBalance {
     updatedAt?: Date;
 }
 export declare function normalizeBalance(balance: string, decimals: number): NormalizedTokenBalance;
+export declare function formatOriginalBalance(balance: string, decimals: number): NormalizedTokenBalance;
 export declare function isContract(provider: Provider, address: string): Promise<boolean>;
 export declare function toEthBigNumber(value: BigNumber | string | number): EthBigNumber;
 export declare function genTotpCode(secret: string, timestamp?: number): string;

--- a/functions/common/lib.esm/utils.js
+++ b/functions/common/lib.esm/utils.js
@@ -61,6 +61,14 @@ export function normalizeBalance(balance, decimals) {
         };
     }
 }
+export function formatOriginalBalance(balance, decimals) {
+    const normalized = new BigNumber(balance).div(new BigNumber(10).pow(decimals));
+    return {
+        value: balance,
+        normalized: normalized.toString(10),
+        updatedAt: new Date(),
+    };
+}
 export async function isContract(provider, address) {
     try {
         const code = await provider.getCode(address);

--- a/functions/common/lib/utils.d.ts
+++ b/functions/common/lib/utils.d.ts
@@ -13,6 +13,7 @@ export interface NormalizedTokenBalance {
     updatedAt?: Date;
 }
 export declare function normalizeBalance(balance: string, decimals: number): NormalizedTokenBalance;
+export declare function formatOriginalBalance(balance: string, decimals: number): NormalizedTokenBalance;
 export declare function isContract(provider: Provider, address: string): Promise<boolean>;
 export declare function toEthBigNumber(value: BigNumber | string | number): EthBigNumber;
 export declare function genTotpCode(secret: string, timestamp?: number): string;

--- a/functions/common/lib/utils.js
+++ b/functions/common/lib/utils.js
@@ -12,7 +12,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.matchTotpCode = exports.genTotpCode = exports.toEthBigNumber = exports.isContract = exports.normalizeBalance = exports.toHex = exports.truncateAddress = exports.prettyPrintTimestamp = exports.prettyPrintTxHash = exports.prettyPrintAddress = exports.hash = void 0;
+exports.matchTotpCode = exports.genTotpCode = exports.toEthBigNumber = exports.isContract = exports.formatOriginalBalance = exports.normalizeBalance = exports.toHex = exports.truncateAddress = exports.prettyPrintTimestamp = exports.prettyPrintTxHash = exports.prettyPrintAddress = exports.hash = void 0;
 const ethers_1 = require("ethers");
 const bignumber_js_1 = require("bignumber.js");
 const totp_generator_1 = __importDefault(require("totp-generator"));
@@ -82,6 +82,15 @@ function normalizeBalance(balance, decimals) {
     }
 }
 exports.normalizeBalance = normalizeBalance;
+function formatOriginalBalance(balance, decimals) {
+    const normalized = new bignumber_js_1.BigNumber(balance).div(new bignumber_js_1.BigNumber(10).pow(decimals));
+    return {
+        value: balance,
+        normalized: normalized.toString(10),
+        updatedAt: new Date(),
+    };
+}
+exports.formatOriginalBalance = formatOriginalBalance;
 function isContract(provider, address) {
     return __awaiter(this, void 0, void 0, function* () {
         try {

--- a/functions/common/src/utils.ts
+++ b/functions/common/src/utils.ts
@@ -85,6 +85,20 @@ export function normalizeBalance(
   }
 }
 
+export function formatOriginalBalance(
+  balance: string,
+  decimals: number
+) : NormalizedTokenBalance {
+  const normalized = new BigNumber(balance).div(
+      new BigNumber(10).pow(decimals)
+  );
+  return {
+    value: balance,
+    normalized: normalized.toString(10),
+    updatedAt: new Date(),
+  }
+}
+
 export async function isContract(
     provider: Provider,
     address: string

--- a/src/components/RedPacketHistoryList.vue
+++ b/src/components/RedPacketHistoryList.vue
@@ -772,7 +772,7 @@ const share = (redPacket: RedPacketDB | undefined) => {
 
 const normalize = (balance: string | undefined, token: Token) : string => {
   const normalizedValue = formatOriginalBalance(balance || "0", token.decimals).normalized;
-  if (normalizedValue.length <= 8) {
+  if (normalizedValue.length <= 15) {
     return normalizedValue;
   } else {
     return normalizeBalance(balance || "0", token.decimals).normalized;

--- a/src/components/RedPacketHistoryList.vue
+++ b/src/components/RedPacketHistoryList.vue
@@ -456,7 +456,7 @@ import Loading from "@/components/Loading.vue";
 import { useAccountStore } from '@/stores/account';
 import { useTokenStore } from '@/stores/token';
 import { queryRedPacketInfo, queryErc721RedPacketInfo } from "@/web3/redpacket";
-import { normalizeBalance } from "../../functions/common";
+import { normalizeBalance, formatOriginalBalance } from "../../functions/common";
 import type { Token } from "../../functions/common";
 import type { RedPacket } from "../../functions/redpacket";
 import { options } from "@/assets/imageAssets";
@@ -771,7 +771,12 @@ const share = (redPacket: RedPacketDB | undefined) => {
 };
 
 const normalize = (balance: string | undefined, token: Token) : string => {
-  return normalizeBalance(balance || "0", token.decimals).normalized;
+  const normalizedValue = formatOriginalBalance(balance || "0", token.decimals).normalized;
+  if (normalizedValue.length <= 8) {
+    return normalizedValue;
+  } else {
+    return normalizeBalance(balance || "0", token.decimals).normalized;
+  }
 }
 
 const normalizedDbBalance = (op: CreateRedPacketOp) : string => {

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -29,5 +29,5 @@ if (import.meta.env.VITE_ENVIRONMENT !== 'production') {
 if (import.meta.env.VITE_USE_FUNCTIONS_EMULATOR === 'true') {
     connectFunctionsEmulator(functions, 'localhost', 5001);
     connectStorageEmulator(storage, "localhost", 9199);
-    // connectAuthEmulator(auth, "http://localhost:9099");
+    connectAuthEmulator(auth, "http://localhost:9099");
 }

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -29,5 +29,5 @@ if (import.meta.env.VITE_ENVIRONMENT !== 'production') {
 if (import.meta.env.VITE_USE_FUNCTIONS_EMULATOR === 'true') {
     connectFunctionsEmulator(functions, 'localhost', 5001);
     connectStorageEmulator(storage, "localhost", 9199);
-    connectAuthEmulator(auth, "http://localhost:9099");
+    // connectAuthEmulator(auth, "http://localhost:9099");
 }


### PR DESCRIPTION
This diff is to fix the created token airdrop amount number format on the luck history page. The issue was showing 0 when the amount is too small, ex. 0.0000001 will be shown as 0.

Changes include:
- added formatOriginalBalance function in common to return the original unnormalized number
- conditionally render the amount. if the amount length is longer than 15, then show 0, if not, show the original number with a pretty print