### PR TITLE
[ci/cd] Add ci and cd pipelines for building and deploying

### DIFF
--- a/.github/actions/early-terminator/action.yml
+++ b/.github/actions/early-terminator/action.yml
@@ -1,0 +1,40 @@
+name: "early terminate"
+description: |
+  Terminate CI workflow earlier once job failure is detected
+inputs:
+  github-token:
+    description: 'Github token'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - name: Post test results on PR
+      uses: actions/github-script@v4.0.2
+      with:
+        script: |
+            // use github REST apis: https://docs.github.com/en/rest/reference/actions#workflow-runs
+            const https = require('https');
+            const options = {
+              hostname: 'api.github.com',
+              path: `/repos/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}/cancel`,
+              headers: {
+                'Authorization': `token ${{ inputs.github-token }}`,
+                'Content-Type': 'application/json',
+                'User-Agent': 'actions/cancel-action'
+              },
+              method: 'POST'
+            }
+            const req = https.request(options, res => {
+              console.log(`statusCode: ${res.statusCode}`)
+              res.on('data', d => {
+                if (res.statusCode != 202) {
+                  let msg = JSON.parse(d)
+                  console.log(`Error: ${msg}`)
+                }
+              })
+            })
+            req.on('error', (error) => {
+              console.log(error)
+            })
+            req.end();

--- a/.github/actions/env-cleanup/action.yml
+++ b/.github/actions/env-cleanup/action.yml
@@ -1,0 +1,11 @@
+name: "CI Environment Teardown"
+description: "Teardown the environment for CI jobs"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for changed and untracked files
+      run: |
+        sudo chmod -R u+r+x ./scripts/changed-files.sh
+        ./scripts/changed-files.sh
+      shell: bash

--- a/.github/actions/env-setup/action.yml
+++ b/.github/actions/env-setup/action.yml
@@ -1,0 +1,14 @@
+name: "CI Environment Setup"
+description: |
+  Setup a common environment for CI jobs.
+  This should in general be a no-op as it should be run inside a docker container which already has all the components installed.
+  Importantly the installation script checks the versions of tools and will install newer versions if specified for most tools.
+runs:
+  using: "composite"
+  steps:
+    - name: Install yarn
+      run: npm install --global yarn
+      shell: bash
+    - name: Install yarn
+      run: npm install --save-dev typescript --force
+      shell: bash

--- a/.github/workflow/ci-test.yml
+++ b/.github/workflow/ci-test.yml
@@ -1,0 +1,81 @@
+name: ci-test
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  setup_env:
+    name: setup-environment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 18
+      - uses: ./.github/actions/env-setup
+      - uses: ./.github/actions/env-cleanup
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs:
+      - setup_env
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 18
+      - uses: ./.github/actions/env-setup
+      - name: Node info
+        run: node -v
+      - run: npm i totp-generator
+      - name: Build the project
+        run: npm run build
+      - uses: ./.github/actions/env-cleanup
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+
+  push_and deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci && npm run build
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BRIDGE23_27764 }}'
+          channelId: live
+          projectId: bridge23-27764
+        
+  success:
+    name: ci-test-success
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    #always run this job even if needed jobs failed or are skipped.
+    if: ${{ always() }}
+    needs:
+      - setup_env
+      - build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/env-cleanup
+      - run: |
+          echo setup_env: ${{ needs.setup_env.result }}
+          echo build: ${{ needs.build.result }}
+          success="${{
+            needs.setup_env.result=='success'
+            && needs.build.result=='success'
+          }}"
+          if [[ "$success" != "true" ]]; then
+            exit 1;
+          fi

--- a/.github/workflow/push-to-firebase.yml
+++ b/.github/workflow/push-to-firebase.yml
@@ -1,0 +1,21 @@
+name: Deploy to Firebase Hosting after diff merge
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci && npm run build
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BRIDGE23_27764 }}'
+          channelId: live
+          projectId: bridge23-27764
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator

--- a/scripts/changed-files.sh
+++ b/scripts/changed-files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Check for modified or untracked files after CI has run
+diff="$(git diff)"
+echo "${diff}"
+changed_files="$(git status --porcelain)"
+echo "${changed_files}"
+
+# If there is unexpected file changes, reset git repo to HEAD for cleanning up
+if [[ -z "${changed_files}" || -z "${diff}" ]]; then
+    git reset --hard HEAD
+fi


### PR DESCRIPTION
Added CI pipeline: **ci-test**
Added CD pipeline: **push-to-firebase**

```ci-test``` workflow will be triggered once PR is created, it has basic testing coverage with building and compiling stages, to avoid un-workable code sneak into production, its running result will be a blocker signal for PR merge.
```push-to-firebase``` workflow will be triggered once PR is merged, it will build and push current codebase include latest code change to corresponding firebase project, AKA: bridge23-27764