### PR TITLE
Update the example app to call new authproof generation func 

### DIFF
--- a/example-apps/Token-EasySending/src/web3/operation.ts
+++ b/example-apps/Token-EasySending/src/web3/operation.ts
@@ -80,14 +80,8 @@ export async function buildUserOpRequest(
     } as { params: UserOpRequest, deploy?: DeployRequest };
 
     if (!deployed) {
-        const { proof } = await genDeployAuthProof(data);
-        const authProof = {
-            authType: hash(proof.authType),
-            identityType: hash(proof.identityType),
-            issuedAt: EthBigNumber.from(proof.issuedAt),
-            signature: proof.signature,
-        } as AuthProofInput;
-        result.deploy = {authProof, owner: walletAccount};
+        const { proof } = await genDeployAuthProof();
+        result.deploy = {authProof: proof, owner: walletAccount};
     }
     return result;
 }

--- a/functions/common/lib.esm/abi/HEXLINK_ABI.json
+++ b/functions/common/lib.esm/abi/HEXLINK_ABI.json
@@ -1,16 +1,5 @@
 [
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "accountBase",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
         "inputs": [],
         "name": "Ownable__NotOwner",
         "type": "error"
@@ -68,7 +57,7 @@
                 "type": "address"
             }
         ],
-        "name": "Deploy",
+        "name": "Deployed",
         "type": "event"
     },
     {
@@ -95,25 +84,6 @@
         "inputs": [
             {
                 "indexed": true,
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "Reset",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
                 "internalType": "address",
                 "name": "implementation",
                 "type": "address"
@@ -124,7 +94,7 @@
     },
     {
         "inputs": [],
-        "name": "accountBase",
+        "name": "accountImplementation",
         "outputs": [
             {
                 "internalType": "address",
@@ -137,112 +107,72 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            }
-        ],
-        "name": "addressOfName",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
             {
                 "components": [
                     {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
                         "internalType": "bytes32",
-                        "name": "identityType",
+                        "name": "schema",
                         "type": "bytes32"
                     },
                     {
                         "internalType": "bytes32",
-                        "name": "authType",
+                        "name": "domain",
                         "type": "bytes32"
                     },
                     {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
+                        "internalType": "bytes32",
+                        "name": "handle",
+                        "type": "bytes32"
                     }
                 ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
-            }
-        ],
-        "name": "bumpNonce",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
+                "internalType": "struct Name",
                 "name": "name",
-                "type": "bytes32"
+                "type": "tuple"
             },
             {
                 "internalType": "bytes",
-                "name": "txData",
+                "name": "data",
                 "type": "bytes"
             },
             {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
+                "internalType": "bytes",
+                "name": "authProof",
+                "type": "bytes"
             }
         ],
         "name": "deploy",
         "outputs": [
             {
                 "internalType": "address",
-                "name": "",
+                "name": "account",
                 "type": "address"
             }
         ],
         "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "schema",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "domain",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRegistry",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
         "type": "function"
     },
     {
@@ -267,8 +197,13 @@
             },
             {
                 "internalType": "address",
-                "name": "oracleRegistry",
+                "name": "accountImpl",
                 "type": "address"
+            },
+            {
+                "internalType": "address[]",
+                "name": "registries",
+                "type": "address[]"
             }
         ],
         "name": "init",
@@ -284,20 +219,7 @@
                 "type": "bytes32"
             }
         ],
-        "name": "nonce",
-        "outputs": [
-            {
-                "internalType": "uint96",
-                "name": "",
-                "type": "uint96"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "oracleRegistry",
+        "name": "ownedAccount",
         "outputs": [
             {
                 "internalType": "address",
@@ -322,41 +244,6 @@
         "type": "function"
     },
     {
-        "inputs": [
-            {
-                "components": [
-                    {
-                        "internalType": "address",
-                        "name": "to",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "value",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "callData",
-                        "type": "bytes"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "callGasLimit",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct Op[]",
-                "name": "ops",
-                "type": "tuple[]"
-            }
-        ],
-        "name": "process",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
-    },
-    {
         "inputs": [],
         "name": "proxiableUUID",
         "outputs": [
@@ -372,174 +259,12 @@
     {
         "inputs": [
             {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
                 "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
-            }
-        ],
-        "name": "reset",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof1",
-                "type": "tuple"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof2",
-                "type": "tuple"
-            }
-        ],
-        "name": "reset2Fac",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
-            }
-        ],
-        "name": "reset2Stage",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "oracleRegistry",
+                "name": "registry",
                 "type": "address"
             }
         ],
-        "name": "setOracleRegistry",
+        "name": "setRegistry",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
@@ -558,29 +283,16 @@
         "type": "function"
     },
     {
-        "inputs": [],
-        "name": "ttl",
-        "outputs": [
+        "inputs": [
             {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
+                "internalType": "address",
+                "name": "accountImpl",
+                "type": "address"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "twoStageLock",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
+        "name": "upgradeAccount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
         "type": "function"
     },
     {

--- a/functions/common/lib.esm/addresses.json
+++ b/functions/common/lib.esm/addresses.json
@@ -1,6 +1,6 @@
 {
     "goerli": {
-        "hexlink": "0xbad6a7948a1d3031ee7236d0180b6271fa569148",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -16,7 +16,7 @@
         ]
     },
     "mumbai": {
-        "hexlink": "0x78317ef8b020Fe10e845ab8723403cF1e58Ef1Cc",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -45,7 +45,7 @@
         ]
     },
     "arbitrum": {
-        "hexlink": "0x1e47cA3F46619f8A5CBFB98a23f564c9865E58ce",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -61,7 +61,7 @@
         ]
     },
     "arbitrum_testnet": {
-        "hexlink": "0x7e0B0332aDbEC1a84E1E264f308AE581fcda5684",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -71,7 +71,7 @@
         ]
     },
     "arbitrum_nova": {
-        "hexlink": "0x1e47cA3F46619f8A5CBFB98a23f564c9865E58ce",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -86,7 +86,7 @@
         ]
     },
     "OKT": {
-        "hexlink": "0xE0CBB44Ab7C2f42a3AaCBf8E8C37BEb9C53118b5",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x61E1945CfbFb945f4156813410Ea6E34e39fbddB",
             "decimals": 18

--- a/functions/common/lib.esm/oracle.d.ts
+++ b/functions/common/lib.esm/oracle.d.ts
@@ -1,9 +1,6 @@
 import type { Provider } from "@ethersproject/providers";
-import type { AuthProof } from "./types";
-export declare function genDeployAuthProof(provider: Provider, nameHash: string, owner: string, data: string | [], genAuthProof: (request: {
+export declare function genDeployAuthProof(provider: Provider, owner: string, genAuthProof: (request: {
     requestId: string;
-    version?: number;
-}) => Promise<AuthProof>, version?: number): Promise<{
-    initData: string;
-    proof: AuthProof;
+}) => Promise<string>): Promise<{
+    proof: string;
 }>;

--- a/functions/common/lib.esm/types.d.ts
+++ b/functions/common/lib.esm/types.d.ts
@@ -41,6 +41,6 @@ export interface AuthProofInput {
     signature: string;
 }
 export interface DeployRequest {
-    authProof: AuthProofInput;
+    authProof: string;
     owner: string;
 }

--- a/functions/common/lib/abi/HEXLINK_ABI.json
+++ b/functions/common/lib/abi/HEXLINK_ABI.json
@@ -1,16 +1,5 @@
 [
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "accountBase",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
         "inputs": [],
         "name": "Ownable__NotOwner",
         "type": "error"
@@ -68,7 +57,7 @@
                 "type": "address"
             }
         ],
-        "name": "Deploy",
+        "name": "Deployed",
         "type": "event"
     },
     {
@@ -95,25 +84,6 @@
         "inputs": [
             {
                 "indexed": true,
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "Reset",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
                 "internalType": "address",
                 "name": "implementation",
                 "type": "address"
@@ -124,7 +94,7 @@
     },
     {
         "inputs": [],
-        "name": "accountBase",
+        "name": "accountImplementation",
         "outputs": [
             {
                 "internalType": "address",
@@ -137,112 +107,72 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            }
-        ],
-        "name": "addressOfName",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
             {
                 "components": [
                     {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
                         "internalType": "bytes32",
-                        "name": "identityType",
+                        "name": "schema",
                         "type": "bytes32"
                     },
                     {
                         "internalType": "bytes32",
-                        "name": "authType",
+                        "name": "domain",
                         "type": "bytes32"
                     },
                     {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
+                        "internalType": "bytes32",
+                        "name": "handle",
+                        "type": "bytes32"
                     }
                 ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
-            }
-        ],
-        "name": "bumpNonce",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
+                "internalType": "struct Name",
                 "name": "name",
-                "type": "bytes32"
+                "type": "tuple"
             },
             {
                 "internalType": "bytes",
-                "name": "txData",
+                "name": "data",
                 "type": "bytes"
             },
             {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
+                "internalType": "bytes",
+                "name": "authProof",
+                "type": "bytes"
             }
         ],
         "name": "deploy",
         "outputs": [
             {
                 "internalType": "address",
-                "name": "",
+                "name": "account",
                 "type": "address"
             }
         ],
         "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "schema",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "domain",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRegistry",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
         "type": "function"
     },
     {
@@ -267,8 +197,13 @@
             },
             {
                 "internalType": "address",
-                "name": "oracleRegistry",
+                "name": "accountImpl",
                 "type": "address"
+            },
+            {
+                "internalType": "address[]",
+                "name": "registries",
+                "type": "address[]"
             }
         ],
         "name": "init",
@@ -284,20 +219,7 @@
                 "type": "bytes32"
             }
         ],
-        "name": "nonce",
-        "outputs": [
-            {
-                "internalType": "uint96",
-                "name": "",
-                "type": "uint96"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "oracleRegistry",
+        "name": "ownedAccount",
         "outputs": [
             {
                 "internalType": "address",
@@ -322,41 +244,6 @@
         "type": "function"
     },
     {
-        "inputs": [
-            {
-                "components": [
-                    {
-                        "internalType": "address",
-                        "name": "to",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "value",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "callData",
-                        "type": "bytes"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "callGasLimit",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct Op[]",
-                "name": "ops",
-                "type": "tuple[]"
-            }
-        ],
-        "name": "process",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
-    },
-    {
         "inputs": [],
         "name": "proxiableUUID",
         "outputs": [
@@ -372,174 +259,12 @@
     {
         "inputs": [
             {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
                 "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
-            }
-        ],
-        "name": "reset",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof1",
-                "type": "tuple"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof2",
-                "type": "tuple"
-            }
-        ],
-        "name": "reset2Fac",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "issuedAt",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "identityType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes32",
-                        "name": "authType",
-                        "type": "bytes32"
-                    },
-                    {
-                        "internalType": "bytes",
-                        "name": "signature",
-                        "type": "bytes"
-                    }
-                ],
-                "internalType": "struct AuthProof",
-                "name": "proof",
-                "type": "tuple"
-            }
-        ],
-        "name": "reset2Stage",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "oracleRegistry",
+                "name": "registry",
                 "type": "address"
             }
         ],
-        "name": "setOracleRegistry",
+        "name": "setRegistry",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
@@ -558,29 +283,16 @@
         "type": "function"
     },
     {
-        "inputs": [],
-        "name": "ttl",
-        "outputs": [
+        "inputs": [
             {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
+                "internalType": "address",
+                "name": "accountImpl",
+                "type": "address"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "twoStageLock",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
+        "name": "upgradeAccount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
         "type": "function"
     },
     {

--- a/functions/common/lib/addresses.json
+++ b/functions/common/lib/addresses.json
@@ -1,6 +1,6 @@
 {
     "goerli": {
-        "hexlink": "0xbad6a7948a1d3031ee7236d0180b6271fa569148",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -16,7 +16,7 @@
         ]
     },
     "mumbai": {
-        "hexlink": "0x78317ef8b020Fe10e845ab8723403cF1e58Ef1Cc",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -45,7 +45,7 @@
         ]
     },
     "arbitrum": {
-        "hexlink": "0x1e47cA3F46619f8A5CBFB98a23f564c9865E58ce",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -61,7 +61,7 @@
         ]
     },
     "arbitrum_testnet": {
-        "hexlink": "0x7e0B0332aDbEC1a84E1E264f308AE581fcda5684",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -71,7 +71,7 @@
         ]
     },
     "arbitrum_nova": {
-        "hexlink": "0x1e47cA3F46619f8A5CBFB98a23f564c9865E58ce",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -86,7 +86,7 @@
         ]
     },
     "OKT": {
-        "hexlink": "0xE0CBB44Ab7C2f42a3AaCBf8E8C37BEb9C53118b5",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x61E1945CfbFb945f4156813410Ea6E34e39fbddB",
             "decimals": 18

--- a/functions/common/lib/oracle.d.ts
+++ b/functions/common/lib/oracle.d.ts
@@ -1,9 +1,6 @@
 import type { Provider } from "@ethersproject/providers";
-import type { AuthProof } from "./types";
-export declare function genDeployAuthProof(provider: Provider, nameHash: string, owner: string, data: string | [], genAuthProof: (request: {
+export declare function genDeployAuthProof(provider: Provider, owner: string, genAuthProof: (request: {
     requestId: string;
-    version?: number;
-}) => Promise<AuthProof>, version?: number): Promise<{
-    initData: string;
-    proof: AuthProof;
+}) => Promise<string>): Promise<{
+    proof: string;
 }>;

--- a/functions/common/lib/oracle.js
+++ b/functions/common/lib/oracle.js
@@ -13,26 +13,27 @@ exports.genDeployAuthProof = void 0;
 const ethers_1 = require("ethers");
 const account_1 = require("./account");
 const hexlink_1 = require("./hexlink");
-const genRequestId = function (provider, nameHash, func, data) {
+const buildAccountInitData = (owner) => __awaiter(void 0, void 0, void 0, function* () {
+    return account_1.accountInterface.encodeFunctionData("init", [owner]);
+});
+const genRequestId = function (provider, owner, func) {
     return __awaiter(this, void 0, void 0, function* () {
         const hexlink = yield (0, hexlink_1.hexlContract)(provider);
-        const result = ethers_1.ethers.utils.keccak256(ethers_1.ethers.utils.defaultAbiCoder.encode(["bytes4", "bytes", "address", "uint256", "uint256"], [
+        const data = buildAccountInitData(owner);
+        const requestId = ethers_1.ethers.utils.keccak256(ethers_1.ethers.utils.defaultAbiCoder.encode(["bytes4", "address", "uint256", "bytes"], [
             func,
-            data,
             hexlink.address,
             (yield provider.getNetwork()).chainId,
-            yield hexlink.nonce(nameHash),
+            data
         ]));
-        return result;
+        return requestId;
     });
 };
-function genDeployAuthProof(provider, nameHash, owner, data, genAuthProof, version) {
+function genDeployAuthProof(provider, owner, genAuthProof) {
     return __awaiter(this, void 0, void 0, function* () {
-        const initData = account_1.accountInterface.encodeFunctionData("init", [owner, data]);
-        const requestId = yield genRequestId(provider, nameHash, hexlink_1.hexlInterface.getSighash("deploy"), initData);
+        const requestId = yield genRequestId(provider, owner, hexlink_1.hexlInterface.getSighash("deploy"));
         return {
-            initData,
-            proof: yield genAuthProof({ requestId, version }),
+            proof: yield genAuthProof({ requestId }),
         };
     });
 }

--- a/functions/common/lib/types.d.ts
+++ b/functions/common/lib/types.d.ts
@@ -41,6 +41,6 @@ export interface AuthProofInput {
     signature: string;
 }
 export interface DeployRequest {
-    authProof: AuthProofInput;
+    authProof: string;
     owner: string;
 }

--- a/functions/common/src/abi/HEXLINK_ABI.json
+++ b/functions/common/src/abi/HEXLINK_ABI.json
@@ -1,16 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "accountBase",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
     "inputs": [],
     "name": "Ownable__NotOwner",
     "type": "error"
@@ -68,7 +57,7 @@
         "type": "address"
       }
     ],
-    "name": "Deploy",
+    "name": "Deployed",
     "type": "event"
   },
   {
@@ -95,25 +84,6 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "bytes32",
-        "name": "name",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "Reset",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
         "internalType": "address",
         "name": "implementation",
         "type": "address"
@@ -124,7 +94,7 @@
   },
   {
     "inputs": [],
-    "name": "accountBase",
+    "name": "accountImplementation",
     "outputs": [
       {
         "internalType": "address",
@@ -137,112 +107,72 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "name",
-        "type": "bytes32"
-      }
-    ],
-    "name": "addressOfName",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "name",
-        "type": "bytes32"
-      },
       {
         "components": [
           {
-            "internalType": "uint256",
-            "name": "issuedAt",
-            "type": "uint256"
-          },
-          {
             "internalType": "bytes32",
-            "name": "identityType",
+            "name": "schema",
             "type": "bytes32"
           },
           {
             "internalType": "bytes32",
-            "name": "authType",
+            "name": "domain",
             "type": "bytes32"
           },
           {
-            "internalType": "bytes",
-            "name": "signature",
-            "type": "bytes"
+            "internalType": "bytes32",
+            "name": "handle",
+            "type": "bytes32"
           }
         ],
-        "internalType": "struct AuthProof",
-        "name": "proof",
-        "type": "tuple"
-      }
-    ],
-    "name": "bumpNonce",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
+        "internalType": "struct Name",
         "name": "name",
-        "type": "bytes32"
+        "type": "tuple"
       },
       {
         "internalType": "bytes",
-        "name": "txData",
+        "name": "data",
         "type": "bytes"
       },
       {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "issuedAt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "identityType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "authType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes",
-            "name": "signature",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct AuthProof",
-        "name": "proof",
-        "type": "tuple"
+        "internalType": "bytes",
+        "name": "authProof",
+        "type": "bytes"
       }
     ],
     "name": "deploy",
     "outputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "account",
         "type": "address"
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "schema",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "domain",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRegistry",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -267,8 +197,13 @@
       },
       {
         "internalType": "address",
-        "name": "oracleRegistry",
+        "name": "accountImpl",
         "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "registries",
+        "type": "address[]"
       }
     ],
     "name": "init",
@@ -284,20 +219,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "nonce",
-    "outputs": [
-      {
-        "internalType": "uint96",
-        "name": "",
-        "type": "uint96"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "oracleRegistry",
+    "name": "ownedAccount",
     "outputs": [
       {
         "internalType": "address",
@@ -322,41 +244,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "to",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "value",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes",
-            "name": "callData",
-            "type": "bytes"
-          },
-          {
-            "internalType": "uint256",
-            "name": "callGasLimit",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Op[]",
-        "name": "ops",
-        "type": "tuple[]"
-      }
-    ],
-    "name": "process",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "proxiableUUID",
     "outputs": [
@@ -372,174 +259,12 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "name",
-        "type": "bytes32"
-      },
-      {
         "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "issuedAt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "identityType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "authType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes",
-            "name": "signature",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct AuthProof",
-        "name": "proof",
-        "type": "tuple"
-      }
-    ],
-    "name": "reset",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "name",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "issuedAt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "identityType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "authType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes",
-            "name": "signature",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct AuthProof",
-        "name": "proof1",
-        "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "issuedAt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "identityType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "authType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes",
-            "name": "signature",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct AuthProof",
-        "name": "proof2",
-        "type": "tuple"
-      }
-    ],
-    "name": "reset2Fac",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "name",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "issuedAt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "identityType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "authType",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes",
-            "name": "signature",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct AuthProof",
-        "name": "proof",
-        "type": "tuple"
-      }
-    ],
-    "name": "reset2Stage",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "oracleRegistry",
+        "name": "registry",
         "type": "address"
       }
     ],
-    "name": "setOracleRegistry",
+    "name": "setRegistry",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -558,29 +283,16 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "ttl",
-    "outputs": [
+    "inputs": [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "accountImpl",
+        "type": "address"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "twoStageLock",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
+    "name": "upgradeAccount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/functions/common/src/addresses.json
+++ b/functions/common/src/addresses.json
@@ -1,6 +1,6 @@
 {
     "goerli": {
-        "hexlink": "0xbad6a7948a1d3031ee7236d0180b6271fa569148",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -16,7 +16,7 @@
         ]
     },
     "mumbai": {
-        "hexlink": "0x78317ef8b020Fe10e845ab8723403cF1e58Ef1Cc",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -45,7 +45,7 @@
         ]
     },
     "arbitrum": {
-        "hexlink": "0x1e47cA3F46619f8A5CBFB98a23f564c9865E58ce",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -61,7 +61,7 @@
         ]
     },
     "arbitrum_testnet": {
-        "hexlink": "0x7e0B0332aDbEC1a84E1E264f308AE581fcda5684",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -71,7 +71,7 @@
         ]
     },
     "arbitrum_nova": {
-        "hexlink": "0x1e47cA3F46619f8A5CBFB98a23f564c9865E58ce",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x0000000000000000000000000000000000000000",
             "decimals": 18
@@ -86,7 +86,7 @@
         ]
     },
     "OKT": {
-        "hexlink": "0xE0CBB44Ab7C2f42a3AaCBf8E8C37BEb9C53118b5",
+        "hexlink": "0x4c552dC72756A690883f9e8955B231c43c4E598e",
         "nativeCoin": {
             "address": "0x61E1945CfbFb945f4156813410Ea6E34e39fbddB",
             "decimals": 18

--- a/functions/common/src/types.ts
+++ b/functions/common/src/types.ts
@@ -49,6 +49,6 @@ export interface AuthProofInput {
 }
 
 export interface DeployRequest {
-  authProof: AuthProofInput,
+  authProof: string;
   owner: string,
 }


### PR DESCRIPTION
This change is to update the example app to call the new email authproof generation function while sending token.

Note: updating deploy logic would be in a different pr.